### PR TITLE
Provide extension settings for estimation options

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,21 @@
   "ahaExtension": {
     "cspSources": [],
     "contributes": {
+      "settings": {
+        "options": {
+          "title": "Estimate options",
+          "type": "number",
+          "scope": ["account"],
+          "array": true,
+          "default": [0, 1, 2, 3, 5, 8]
+        },
+        "includeUnknown": {
+          "title": "Include unknown option",
+          "type": "boolean",
+          "scope": ["account"],
+          "default": false
+        }
+      },
       "views": {
         "planningPoker": {
           "title": "Planning poker",


### PR DESCRIPTION
Adds two new extension settings:

* Options – number array for the list of valid estimation values (e.g. 1, 2, 3, 5, 8)
* Include unknown – boolean indicating whather to allow an "Unknown" estimate

We've had requests for this from customers for a long while now, but held off providing this to drive end users to customize the extension instead. With the new focus on SAFe and plans to auto-install this extension for SAFe teams, it seems reasonable to bake these options in now.