### PR TITLE
Show the number of votes in the vote form

### DIFF
--- a/src/views/planningPoker.tsx
+++ b/src/views/planningPoker.tsx
@@ -199,6 +199,7 @@ const PlanningPoker = ({ record, initialVotes }) => {
               >
                 See results
               </button>
+              <p className="votes">{votes.length} Votes</p>
             </div>
           </>
         )}

--- a/src/views/planningPoker.tsx
+++ b/src/views/planningPoker.tsx
@@ -197,9 +197,8 @@ const PlanningPoker = ({ record, initialVotes }) => {
                 className="btn btn-small btn-secondary"
                 onClick={() => setHasVoted(true)}
               >
-                See results
+                See {votes.length} votes
               </button>
-              <p className="votes">{votes.length} Votes</p>
             </div>
           </>
         )}

--- a/src/views/planningPokerStyles.tsx
+++ b/src/views/planningPokerStyles.tsx
@@ -21,6 +21,12 @@ export const PlanningPokerStyles = () => (
         white-space: nowrap;
       }
 
+      .planning-poker--controls .votes {
+        text-align: right;
+        margin: 0;
+        font-size: 12px;
+    }
+
       .planning-poker:hover .planning-poker--controls {
         visibility: initial;
       }

--- a/src/views/planningPokerStyles.tsx
+++ b/src/views/planningPokerStyles.tsx
@@ -21,12 +21,6 @@ export const PlanningPokerStyles = () => (
         white-space: nowrap;
       }
 
-      .planning-poker--controls .votes {
-        text-align: right;
-        margin: 0;
-        font-size: 12px;
-    }
-
       .planning-poker:hover .planning-poker--controls {
         visibility: initial;
       }


### PR DESCRIPTION
Added a small label to the voting form that shows how many users already voted:
![image](https://user-images.githubusercontent.com/32839843/223112781-e50bb08e-421a-4930-aead-5d73baf1c611.png)

This was done in case you are waiting for others to place their votes before revealing the votes. When sharing your screen with the team during the voting, you don't want to influence their votes by showing the results while they are still voting. With this change, you can wait until everyone placed their vote.