### PR TITLE
ADT-572: Show planning poker on epics

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
           "host": "attribute",
           "entryPoint": "src/views/planningPoker.tsx",
           "recordTypes": [
+            "Epic",
             "Feature",
             "Requirement"
           ]


### PR DESCRIPTION
<p>Allow the planning poker view to be added to epic layouts.</p>


- Add epics